### PR TITLE
path.resolve "kha.khaPath" to an absolute path

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -11,7 +11,7 @@ function findKha() {
 	let localkhapath = path.resolve(vscode.workspace.rootPath, 'Kha');
 	if (fs.existsSync(localkhapath) && fs.existsSync(path.join(localkhapath, 'Tools', 'khamake', 'out', 'main.js'))) return localkhapath;
 	let khapath = vscode.workspace.getConfiguration('kha').khaPath;
-	if (khapath.length > 0) return khapath;
+	if (khapath.length > 0) return path.resolve(khapath);
 	return path.join(vscode.extensions.getExtension('kodetech.kha').extensionPath, 'Kha');
 }
 


### PR DESCRIPTION
I'm currently trying to use a project local armory sdk and needed to specify the path to the included Kha in the vscode settings.json. This didn't work, but now it does. I also tried to set an already absolute path in the settings.json after this change, and it still worked, so i hope it doesn't break anything.

Project layout:

```
root
    armsdk
        Kha
```

.vscode/settings.json

```
{
    "kha.khaPath": "armsdk/Kha"
}
```
