### PR TITLE
Allow Customizable Kha Build Dir

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -37,7 +37,7 @@ function compile(target, silent) {
 
 	let options = {
 		from: vscode.workspace.rootPath,
-		to: path.join(vscode.workspace.rootPath, 'build'),
+		to: path.join(vscode.workspace.rootPath, vscode.workspace.getConfiguration('kha').buildDir),
 		projectfile: 'khafile.js',
 		target: target,
 		vr: 'none',
@@ -109,7 +109,8 @@ let KhaDisplayArgumentsProvider = {
 
 function updateHaxeArguments(rootPath, hxmlPath) {
 	const hxml = fs.readFileSync(hxmlPath, 'utf8');
-	KhaDisplayArgumentsProvider.update('--cwd ' + path.join(rootPath, 'build') + '\n' + hxml);
+	const buildDir = vscode.workspace.getConfiguration('kha').buildDir;
+	KhaDisplayArgumentsProvider.update('--cwd ' + path.join(rootPath, buildDir) + '\n' + hxml);
 }
 
 function configureVsHaxe(rootPath) {
@@ -169,6 +170,7 @@ function checkProject(rootPath) {
 	configureVsHaxe(rootPath);
 
 	const configuration = vscode.workspace.getConfiguration();
+	const buildDir = vscode.workspace.getConfiguration('kha').buildDir;
 	let config = configuration.get('launch');
 	config.configurations = config.configurations.filter((value) => {
 		return !value.name.startsWith('Kha: ');
@@ -177,7 +179,7 @@ function checkProject(rootPath) {
 		type: 'electron',
 		request: 'launch',
 		name: 'Kha: HTML5',
-		appDir: '${workspaceFolder}/build/debug-html5',
+		appDir: '${workspaceFolder}/' + buildDir + '/debug-html5',
 		sourceMaps: true,
 		preLaunchTask: 'Kha: Build for Debug HTML5'
 	});
@@ -252,11 +254,12 @@ const KhaDebugProvider = {
 
 		folder.uri;
 
+		const buildDir = vscode.workspace.getConfiguration('kha').buildDir;
 		configs.push({
 			name: 'Kha: HTML5',
 			request: 'launch',
 			type: 'electron',
-			appDir: '${workspaceFolder}/build/debug-html5',
+			appDir: '${workspaceFolder}/' + buildDir + '/debug-html5',
 			sourceMaps: true,
 			preLaunchTask: 'Kha: Build for Debug HTML5'
 		});
@@ -374,7 +377,8 @@ exports.activate = (context) => {
 			}
 
 			const rootPath = vscode.workspace.rootPath;
-			const hxmlPath = path.join(rootPath, 'build', 'project-' + choiceToHxml() + '.hxml');
+			const buildDir = vscode.workspace.getConfiguration('kha').buildDir;
+			const hxmlPath = path.join(rootPath, buildDir, 'project-' + choiceToHxml() + '.hxml');
 			if (fs.existsSync(hxmlPath)) {
 				updateHaxeArguments(rootPath, hxmlPath);
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kha",
-	"version": "18.5.3",
+	"version": "18.8.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
 					"type": "string",
 					"default": "",
 					"description": "Path to ffmpeg for extended audio and video format support."
+				},
+				"kha.buildDir": {
+					"type": "string",
+					"default": "build",
+					"description": "Relative path to the Kha build dir for the project."
 				}
 			}
 		},


### PR DESCRIPTION
Added a simple parameterization of the Kha build dir. You can now set the `kha.buildDir` in workspace config. This fixes Haxe completion for Armory3D games by allowing you to set the build dir to the Armory build dir.