### PR TITLE
resolve a relative "kha.khaPath" from workspace root directory

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -11,7 +11,9 @@ function findKha() {
 	let localkhapath = path.resolve(vscode.workspace.rootPath, 'Kha');
 	if (fs.existsSync(localkhapath) && fs.existsSync(path.join(localkhapath, 'Tools', 'khamake', 'out', 'main.js'))) return localkhapath;
 	let khapath = vscode.workspace.getConfiguration('kha').khaPath;
-	if (khapath.length > 0) return path.resolve(khapath);
+	if (khapath.length > 0) {
+		return path.isAbsolute(khapath) ? khapath : path.resolve(vscode.workspace.rootPath, khapath);
+	}
 	return path.join(vscode.extensions.getExtension('kodetech.kha').extensionPath, 'Kha');
 }
 


### PR DESCRIPTION
not sure what changed, but relative paths were resolved from the vscode installation directory instead of the workspace root