### PR TITLE
"Init Kha Project" -> "Kha: Init Project"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"commands": [
 			{
 				"command": "kha.init",
-				"title": "Init Kha Project"
+				"title": "Init Project",
+				"category": "Kha"
 			}
 		],
 		"configuration": {


### PR DESCRIPTION
The latter follows the normal naming conventions for VSCode commands by using the "category" field.

![](https://i.imgur.com/ougPIu3.png)