### PR TITLE
Remove "configuration" from the settings title

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		],
 		"configuration": {
 			"type": "object",
-			"title": "Kha configuration",
+			"title": "Kha",
 			"properties": {
 				"kha.khaPath": {
 					"type": "string",


### PR DESCRIPTION
It looks redundant in VSCode's new Settings UI / most extensions just use the extension name.

![](https://i.imgur.com/9v3Iqne.png)