### PR TITLE
Fix build on Windows with git bash shell

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -293,16 +293,26 @@ const KhaTaskProvider = {
 			}
 
 			let task = null;
+			let khamakePath = path.join(findKha(), 'make.js');
+			let winShell = vscode.workspace.getConfiguration('terminal.integrated.shell').get('windows');
+
+			// On Windows, git bash shell won't accept backward slashes and will fail,
+			// so we explicitly need to convert path to unix-style.
+			if (os.platform() === 'win32' && winShell.indexOf('bash.exe') > -1) {
+				khamakePath = khamakePath.replace(/\\/g, '/');
+			}
+
 			if (vscode.env.appName.includes('Kode')) {
 				let exec = process.execPath;
 				if (exec.indexOf('Kode Studio Helper') >= 0) {
 					const dir = exec.substring(0, exec.lastIndexOf('/'));
 					exec = path.join(dir, '..', '..', '..', '..', 'MacOS', 'Electron');
 				}
-				task = new vscode.Task(kind, `Build for ${system.name}`, 'Kha', new vscode.ProcessExecution(exec, ['--khamake', path.join(findKha(), 'make.js')].concat(args), {cwd: workspaceRoot}), ['$haxe-absolute', '$haxe']);
+				task = new vscode.Task(kind, `Build for ${system.name}`, 'Kha', new vscode.ProcessExecution(exec, ['--khamake', khamakePath].concat(args), {cwd: workspaceRoot}), ['$haxe-absolute', '$haxe']);
 			}
 			else {
-				task = new vscode.Task(kind, vscode.TaskScope.Workspace, `Build for ${system.name}`, 'Kha', new vscode.ShellExecution('node', [path.join(findKha(), 'make.js')].concat(args)), ['$haxe-absolute', '$haxe']);
+				
+				task = new vscode.Task(kind, vscode.TaskScope.Workspace, `Build for ${system.name}`, 'Kha', new vscode.ShellExecution('node', [khamakePath].concat(args)), ['$haxe-absolute', '$haxe']);
 			}
 			task.group = vscode.TaskGroup.Build;
 			tasks.push(task);


### PR DESCRIPTION
This is my attempt at fixing #19.

After some investigation, I've found that problem was in git bash shell that I'm using with VS Code. It won't accept backward slashes, but cmd and PowerShell will do. So with this workaround, if extension detects bash shell on windows, it will covert khamake path to unix style and build will work fine.

Please let me know, if something is wrong with PR, I'll fix that.