### PR TITLE
Enable for use on FreeBSD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kha",
-	"version": "21.3.6",
+	"version": "21.3.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -286,6 +286,11 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 			"dev": true
+		},
+		"child_process": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+			"integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
 		},
 		"circular-json": {
 			"version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -213,10 +213,26 @@
 				"./chrome-sandbox"
 			],
 			"platformId": "linux-x64"
+		},
+		{
+			"description": "Electron for FreeBSD 12.2",
+			"url": "https://github.com/tagattie/FreeBSD-Electron/releases/download/v11.2.3/electron11-11.2.3-freebsd12-amd64.txz",
+			"platforms": [
+				"freebsd"
+			],
+			"architectures": [
+				"x64"
+			],
+			"binaries": [
+				"./usr/local/share/electron11/electron",
+				"./usr/local/share/electron11/chromedriver"
+			],
+			"platformId": "linux-x64"
 		}
 	],
 	"dependencies": {
 		"@microsoft/vscode-file-downloader-api": "^1.0.1",
+		"child_process": "^1.0.2",
 		"mkdirp": "^1.0.4",
 		"yauzl": "^2.10.0"
 	}


### PR DESCRIPTION
Added new dependency "child_process" to use tools available in FreeBSD
to download and install electron.

This may not fly well with you, so feel free to reject or request changes to
it.

I can yank out the part where I use a console to extract and copy the 
electron archive and you upload a respective zip for it. Just as an aside,
using the tarball negates the need of having to `chmod` the files, since
with tar that information is stored/retained.